### PR TITLE
Sticky ELO Filter to left nav for desktop navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -117,26 +117,25 @@
                 margin-right: 70px;
             }
             .filter-container {
-            padding: 25px;
-            color: white;
-            margin-left: 25px;   
-        }
+                padding: 25px;
+                color: white;
+                margin-left: 25px;   
+                position: fixed;
+            }
             .event-sections {
                 max-width: 1000px;
+                margin-left: 250px;
             }
             .event-container {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
-    margin-bottom: 150px;
-    gap: 15px;
-    width: 100%;
-    max-width: 1000px;
-    min-height: 400px;
-}
-                 
+                display: grid;
+                grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+                margin-bottom: 150px;
+                gap: 15px;
+                width: 100%;
+                max-width: 1000px;
+                min-height: 400px;
+            }    
         }
-      
-
     </style>
 </head>
 <body>

--- a/style.css
+++ b/style.css
@@ -19,7 +19,6 @@ h1 {
 }
 
 h2 {
-    text-align: center;
     font-size: 2em;
     margin-bottom: 1.25rem;
     margin-top: 1.5rem;
@@ -154,7 +153,10 @@ html {
 
 /* phone bp */
 @media (max-width: 480px) {
-
+    h2{
+        text-align: center;
+        margin: 1rem 2rem;
+    } 
 
     .event-container {
         grid-template-columns: 100%;


### PR DESCRIPTION
- Sticky the ELO Filter to the left hand side of the screen
  - Makes it easier to scroll tournaments while seeing what your active filter is when browsing on desktop
- Remove `display: flex` from `.main-container` as it was preventing `event` components using the `grid` layout from properly adjusting to different rows when the screen was resized

## Larger Screen
<img width="1284" alt="Screenshot 2025-07-09 at 5 59 53 PM" src="https://github.com/user-attachments/assets/79917e54-eccd-41ed-b757-cba64950f547" />

## Smaller Screen
<img width="744" alt="Screenshot 2025-07-09 at 5 59 35 PM" src="https://github.com/user-attachments/assets/265f6fb8-e6f8-40bd-b34e-a97e4388efb2" />
